### PR TITLE
// var logs string = `__PATH

### DIFF
--- a/wmi_windows.go
+++ b/wmi_windows.go
@@ -135,6 +135,10 @@ func GetLetterToDiskPartition() LetterDiskPartMap {
 	ldreg := regexp.MustCompile(`Win32_LogicalDisk.DeviceID="(?P<b>[A-Za-z]):"`)
 	for _, line := range lines {
 		if found != nil {
+			if ldstrs := ldreg.FindAllStringSubmatch(line, 1); len(ldstrs) != 0 {
+				found = &LetterToDiskPartition{Letter: ldstrs[0][1]}
+				continue
+			}
 			reg := regexp.MustCompile(`Win32_DiskPartition.DeviceID="Disk #(?P<b>[\d]*), Partition #(?P<c>[\d]*)"`)
 			strs := reg.FindAllStringSubmatch(line, 1)
 			if len(strs) != 0 {


### PR DESCRIPTION
// \\GPXAB5373DH0O40\ROOT\CIMV2:Win32_LogicalDisk.DeviceID="C:"
// \\GPXAB5373DH0O40\ROOT\CIMV2:Win32_DiskPartition.DeviceID="Disk #0, Partition #0"
// \\GPXAB5373DH0O40\ROOT\CIMV2:Win32_LogicalDisk.DeviceID="D:"
// \\GPXAB5373DH0O40\ROOT\CIMV2:Win32_DiskPartition.DeviceID="Disk #0, Partition #1"
// \\GPXAB5373DH0O40\ROOT\CIMV2:Win32_LogicalDisk.DeviceID="E:"
// \\GPXAB5373DH0O40\ROOT\CIMV2:Win32_DiskPartition.DeviceID="Disk #0, Partition #1"
// \\GPXAB5373DH0O40\ROOT\CIMV2:Win32_LogicalDisk.DeviceID="F:"
// \\GPXAB5373DH0O40\ROOT\CIMV2:Win32_DiskPartition.DeviceID="Disk #0, Partition #1"
// \\GPXAB5373DH0O40\ROOT\CIMV2:Win32_LogicalDisk.DeviceID="G:"
// \\GPXAB5373DH0O40\ROOT\CIMV2:Win32_LogicalDisk.DeviceID="I:"
// \\GPXAB5373DH0O40\ROOT\CIMV2:Win32_DiskPartition.DeviceID="Disk #1, Partition #0"

当有个磁盘获取不到分区信息时， 会导致后面的磁盘获取信息失败